### PR TITLE
Reuse identical parameters in supported dialects

### DIFF
--- a/src/dialect/mssql/mssql-query-compiler.ts
+++ b/src/dialect/mssql/mssql-query-compiler.ts
@@ -13,6 +13,16 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
     return `@${this.numParameters}`
   }
 
+  protected override getExistingParameterPlaceholder(
+    parameter: unknown,
+  ): string | undefined {
+    const parameterIndex = this.getExistingParameterIndex(parameter)
+    if (parameterIndex === undefined) {
+      return undefined
+    }
+    return `@${parameterIndex + 1}`
+  }
+
   protected override visitOffset(node: OffsetNode): void {
     super.visitOffset(node)
     this.append(' rows')

--- a/src/dialect/mysql/mysql-query-compiler.ts
+++ b/src/dialect/mysql/mysql-query-compiler.ts
@@ -8,6 +8,10 @@ export class MysqlQueryCompiler extends DefaultQueryCompiler {
     return '?'
   }
 
+  protected override getExistingParameterPlaceholder(_parameter: unknown): undefined {
+    return undefined
+  }
+
   protected override getLeftExplainOptionsWrapper(): string {
     return ''
   }

--- a/src/dialect/sqlite/sqlite-query-compiler.ts
+++ b/src/dialect/sqlite/sqlite-query-compiler.ts
@@ -14,6 +14,10 @@ export class SqliteQueryCompiler extends DefaultQueryCompiler {
     return '?'
   }
 
+  protected override getExistingParameterPlaceholder(_parameter: unknown): undefined {
+    return undefined
+  }
+
   protected override getLeftExplainOptionsWrapper(): string {
     return ''
   }

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1753,8 +1753,12 @@ export class DefaultQueryCompiler
   }
 
   protected appendValue(parameter: unknown): void {
-    this.addParameter(parameter)
-    this.append(this.getCurrentParameterPlaceholder())
+    let parameterPlaceholder = this.getExistingParameterPlaceholder(parameter)
+    if (parameterPlaceholder === undefined) {
+      this.addParameter(parameter)
+      parameterPlaceholder = this.getCurrentParameterPlaceholder()
+    }
+    this.append(parameterPlaceholder)
   }
 
   protected getLeftIdentifierWrapper(): string {
@@ -1763,6 +1767,24 @@ export class DefaultQueryCompiler
 
   protected getRightIdentifierWrapper(): string {
     return '"'
+  }
+
+  protected getExistingParameterIndex(parameter: unknown): number | undefined {
+    const parameterIndex = this.#parameters.indexOf(parameter)
+    if (parameterIndex < 0) {
+      return undefined
+    }
+    return parameterIndex
+  }
+
+  protected getExistingParameterPlaceholder(
+    parameter: unknown,
+  ): string | undefined {
+    const parameterIndex = this.getExistingParameterIndex(parameter)
+    if (parameterIndex === undefined) {
+      return undefined
+    }
+    return '$' + (parameterIndex + 1)
   }
 
   protected getCurrentParameterPlaceholder(): string {


### PR DESCRIPTION
Closes #1387

Updated `DefaultQueryCompiler.appendValue` to try searching for existing parameter placeholder before adding new parameters.

`getExistingParameterPlaceholder` can be overridden to update the placeholder syntax or to disable the functionality (sqlite and mysql don't support this)

Added a test to verify it works correctly